### PR TITLE
feat: allow asdf-helper to be non recursive

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -13,9 +13,15 @@ var (
 )
 
 func install(cmd *cobra.Command, args []string) error {
-	return helper.Install()
+	recursive, err := cmd.Flags().GetBool("recursive")
+	if err != nil {
+		return err
+	}
+
+	return helper.Install(recursive)
 }
 
 func init() {
+	installCmd.Flags().Bool("recursive", true, "run recursively")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/latest.go
+++ b/cmd/latest.go
@@ -23,12 +23,18 @@ func latest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return helper.Latest(hideLatest, includePrereleases)
+	recursive, err := cmd.Flags().GetBool("recursive")
+	if err != nil {
+		return err
+	}
+
+	return helper.Latest(hideLatest, includePrereleases, recursive)
 }
 
 func init() {
 	latestCmd.Flags().Bool("hide-latest", false, "do not print tools already at the latest version")
 	latestCmd.Flags().Bool("include-prereleases", false, "include prereleases")
+	latestCmd.Flags().Bool("recursive", true, "run recursively")
 
 	rootCmd.AddCommand(latestCmd)
 }

--- a/helper/install.go
+++ b/helper/install.go
@@ -2,11 +2,12 @@ package helper
 
 import (
 	"fmt"
+
 	"github.com/ngyewch/asdf-helper/asdf"
 )
 
-func Install() error {
-	return walk(func(asdfHelper *asdf.Helper, name string, version string, constraint string) error {
+func Install(nonRecursive bool) error {
+	return walk(nonRecursive, func(asdfHelper *asdf.Helper, name string, version string, constraint string) error {
 		hasInstall, err := asdfHelper.CheckInstall(name, version)
 		if err != nil {
 			return err

--- a/helper/latest.go
+++ b/helper/latest.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/ngyewch/asdf-helper/asdf"
 )
@@ -23,9 +24,9 @@ func getAllVersions(asdfHelper *asdf.Helper, name string, versionPrefix string, 
 	return allVersions, nil
 }
 
-func Latest(hideLatest bool, includePrereleases bool) error {
+func Latest(hideLatest bool, includePrereleases bool, recursive bool) error {
 	allVersionsMap := make(map[string][]*AsdfVersion, 0)
-	return walk(func(asdfHelper *asdf.Helper, name string, version string, constraint string) error {
+	return walk(recursive, func(asdfHelper *asdf.Helper, name string, version string, constraint string) error {
 		var c *semver.Constraints = nil
 		if constraint != "" {
 			c1, err := semver.NewConstraint(constraint)

--- a/helper/walker.go
+++ b/helper/walker.go
@@ -2,16 +2,17 @@ package helper
 
 import (
 	"fmt"
-	"github.com/denormal/go-gitignore"
-	"github.com/ngyewch/asdf-helper/asdf"
-	"github.com/ngyewch/asdf-helper/util"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/denormal/go-gitignore"
+	"github.com/ngyewch/asdf-helper/asdf"
+	"github.com/ngyewch/asdf-helper/util"
 )
 
-func walk(handler func(asdfHelper *asdf.Helper, name string, version string, constraint string) error) error {
+func walk(recursive bool, handler func(asdfHelper *asdf.Helper, name string, version string, constraint string) error) error {
 	ignore, err := gitignore.NewRepository(".")
 	if err != nil {
 		return err
@@ -27,6 +28,11 @@ func walk(handler func(asdfHelper *asdf.Helper, name string, version string, con
 		if err != nil {
 			return err
 		}
+
+		if path != "." && info.IsDir() && !recursive {
+			return filepath.SkipDir
+		}
+
 		match := ignore.Relative(path, info.IsDir())
 		if match != nil {
 			if match.Ignore() {


### PR DESCRIPTION
Hi, 

Firstly thanks for this tools, it helps me to bootstrap some of my projects.

I would like to add this feature because I would like to run `asdf-helper` on the global `.tool-versions` without installing others `.tool-versions` that could exist on sub-directories.
